### PR TITLE
The new function v3b

### DIFF
--- a/nums/uintb.lua
+++ b/nums/uintb.lua
@@ -280,14 +280,10 @@ M_mt.__tostring =
         return tostring(a._bn)
     end
 
--- Object
+-- Private
 
-function M:new(bits, n)
+local function new(bits, n)
     local o = setmetatable({}, M_mt)
-
-    if self ~= M then
-        return nil, "first argument must be self"
-    end
 
     if bits == nil then
         return nil, "bits required"
@@ -325,37 +321,37 @@ function M.isuint(t)
 end
 
 function M.u8(n)
-    return M:new(8, n)
+    return new(8, n)
 end
 
 function M.u16(n)
-    return M:new(16, n)
+    return new(16, n)
 end
 
 function M.u32(n)
-    return M:new(32, n)
+    return new(32, n)
 end
 
 function M.u64(n)
-    return M:new(64, n)
+    return new(64, n)
 end
 
 function M.u128(n)
-    return M:new(128, n)
+    return new(128, n)
 end
 
 function M.u256(n)
-    return M:new(256, n)
+    return new(256, n)
 end
 
 function M.u512(n)
-    return M:new(512, n)
+    return new(512, n)
 end
 
 -- M
 
 function M:copy()
-    return M:new(self._bits, self._bn)
+    return new(self._bits, self._bn)
 end
 
 function M:set(n)
@@ -388,7 +384,7 @@ function M:swape()
         n = n | (bn(t[i]) << i*8-8)
     end
 
-    return M:new(self._bits, n)
+    return new(self._bits, n)
 end
 
 function M:asnumber()

--- a/nums/uintb.lua
+++ b/nums/uintb.lua
@@ -283,12 +283,11 @@ M_mt.__tostring =
 -- Private
 
 local function new(bits, n)
-    local o = setmetatable({}, M_mt)
-
     if bits == nil then
         return nil, "bits required"
     end
 
+    local o = setmetatable({}, M_mt)
     if M.isuint(bits) then
         o._bits = bits._bits
         o._max = bits._max

--- a/nums/uintb.lua
+++ b/nums/uintb.lua
@@ -347,6 +347,13 @@ function M.u512(n)
     return new(512, n)
 end
 
+function M.new(self, bits, n)
+    if type(self)=="number" and n==nil then -- allow to call M.new(bits, n) instead of M:new(bits, n)
+        bits, n = self, bits
+    end
+    return new(bits, n)
+end
+
 -- M
 
 function M:copy()

--- a/nums/uintn.lua
+++ b/nums/uintn.lua
@@ -282,6 +282,10 @@ M_mt.__tostring =
 -- Private
 
 local function new(bits, n)
+    if bits == nil then
+        return nil, "bits required"
+    end
+
     local o = setmetatable({}, M_mt)
     o._bits = bits
     o._max = 1 << o._bits


### PR DESCRIPTION
update of the previous PR (branch the-new-function-v3)

We have all `module.uNNN()` but `module:new(size)` not `module.new(size)`
I support both, and use the new function internaly without dependance with the exposed function.
```
local uint = `require "nums.uintb"
x = uint.u8()
x = uint.u16()
x = uint.u32()
x = uint.u64()
x = uint.u128()
x = uint.u256()
x = uint.u512()
x = uint.new(512) -- supported now
x = uint:new(512) -- legacy support
```